### PR TITLE
Added improvements on site load speed

### DIFF
--- a/Inspiring_journey.html
+++ b/Inspiring_journey.html
@@ -123,8 +123,8 @@
             </div>
             <article>
                 <div class="section-featured is-featured-image">
-                    <div class="featured-image"
-                        style="background-image: url(https://images.unsplash.com/photo-1522120691812-dcdfb625f397?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=668&q=80)">
+                    <div class="featured-image lazyload"
+                        data-image="https://images.unsplash.com/photo-1522120691812-dcdfb625f397?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=668&q=80">
                     </div>
                     <div class="featured-wrap flex">
                         <div class="featured-content">
@@ -598,7 +598,7 @@
             });
         }
     </script>
-
+<script src="assets/js/lazyload.js"></script>
 
 
 </body>

--- a/Inspiring_journey.html
+++ b/Inspiring_journey.html
@@ -24,8 +24,10 @@
     <meta name="HandheldFriendly" content="True">
     <meta name="MobileOptimized" content="320">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap"
-        rel="stylesheet">
+    <link rel="preconect" href="https://fonts.gstatic.com" crossorigin="">
+    <link rel="preconect" href="https://fonts.googleapis.com" crossorigin="">
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap" as="style">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap">
     <link rel="stylesheet" type="text/css" href="assets/css/screen.css">
     <meta name="description" content="Thoughts, stories and ideas" />
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />

--- a/assets/js/lazyload.js
+++ b/assets/js/lazyload.js
@@ -1,0 +1,17 @@
+document.querySelectorAll('.lazyload').forEach((i) => {
+  if (i) {
+      const observer = new IntersectionObserver((entries) => {
+          observerCallback(entries)
+      },
+      {threshold: 1});    
+      observer.observe(i);
+  }
+})
+
+const observerCallback = (entries) => {
+  entries.forEach((entry) => {
+       if (entry.isIntersecting) {
+          entry.target.style.backgroundImage = `url(${entry.target.getAttribute('data-image')})`;
+       }
+  });
+};

--- a/believeinyourself.html
+++ b/believeinyourself.html
@@ -120,8 +120,8 @@
             </div>
             <article>
                 <div class="section-featured is-featured-image">
-                    <div class="featured-image"
-                        style="background-image: url(https://images.unsplash.com/photo-1528716321680-815a8cdb8cbe?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1010&q=80)">
+                    <div class="featured-image lazyload"
+                        data-image="https://images.unsplash.com/photo-1528716321680-815a8cdb8cbe?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1010&q=80">
                     </div>
                     <div class="featured-wrap flex">
                         <div class="featured-content">
@@ -625,7 +625,7 @@
         });
     }
 </script>
-
+<script src="assets/js/lazyload.js"></script>
 
 </body>
 

--- a/believeinyourself.html
+++ b/believeinyourself.html
@@ -22,8 +22,10 @@
     <meta name="HandheldFriendly" content="True">
     <meta name="MobileOptimized" content="320">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap"
-        rel="stylesheet">
+    <link rel="preconect" href="https://fonts.gstatic.com" crossorigin="">
+    <link rel="preconect" href="https://fonts.googleapis.com" crossorigin="">
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap" as="style">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap">
     <link rel="stylesheet" type="text/css" href="assets/css/screen.css">
     <meta name="description" content="Thoughts, stories and ideas" />
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />

--- a/contact.html
+++ b/contact.html
@@ -9,8 +9,10 @@
     <meta name="HandheldFriendly" content="True">
     <meta name="MobileOptimized" content="320">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap"
-        rel="stylesheet">
+    <link rel="preconect" href="https://fonts.gstatic.com" crossorigin="">
+    <link rel="preconect" href="https://fonts.googleapis.com" crossorigin="">
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap" as="style">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap">
     <link rel="stylesheet" type="text/css" href="assets/css/screen.css?v=62ad10baa0">
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />
     <link rel="canonical" href="" />

--- a/dicision_making.html
+++ b/dicision_making.html
@@ -24,8 +24,10 @@
     <meta name="HandheldFriendly" content="True">
     <meta name="MobileOptimized" content="320">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap"
-        rel="stylesheet">
+    <link rel="preconect" href="https://fonts.gstatic.com" crossorigin="">
+    <link rel="preconect" href="https://fonts.googleapis.com" crossorigin="">
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap" as="style">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap">
     <link rel="stylesheet" type="text/css" href="assets/css/screen.css">
     <meta name="description" content="Thoughts, stories and ideas" />
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />

--- a/dicision_making.html
+++ b/dicision_making.html
@@ -121,8 +121,8 @@
             </div>
             <article>
                 <div class="section-featured is-featured-image">
-                    <div class="featured-image"
-                        style="background-image: url(https://images.unsplash.com/photo-1500856056008-859079534e9e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1651&q=80)">
+                    <div class="featured-image lazyload"
+                        data-image="https://images.unsplash.com/photo-1500856056008-859079534e9e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1651&q=80">
                     </div>
                     <div class="featured-wrap flex">
                         <div class="featured-content">
@@ -539,6 +539,7 @@
     <script src="assets/js/post.js?v=62ad10baa0"></script>
     <script src="assets/js/global.js?v=62ad10baa0"></script>
     <script src="assets/js/ityped.js?v=62ad10baa0"></script>
+    <script src="assets/js/lazyload.js"></script>
     <script>
         function getParameterByName(e, n) {
             n || (n = window.location.href), e = e.replace(/[\[\]]/g, "\\$&");

--- a/emotional-investment.html
+++ b/emotional-investment.html
@@ -24,8 +24,10 @@
     <meta name="HandheldFriendly" content="True">
     <meta name="MobileOptimized" content="320">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap"
-        rel="stylesheet">
+    <link rel="preconect" href="https://fonts.gstatic.com" crossorigin="">
+    <link rel="preconect" href="https://fonts.googleapis.com" crossorigin="">
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap" as="style">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap">
     <link rel="stylesheet" type="text/css" href="assets/css/screen.css">
     <meta name="description" content="Thoughts, stories and ideas" />
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />

--- a/how-to-fail-in-iit-entrace-exam.html
+++ b/how-to-fail-in-iit-entrace-exam.html
@@ -114,8 +114,8 @@
             </div>
             <article>
                 <div class="section-featured is-featured-image">
-                    <div class="featured-image"
-                        style="background-image: url(https://images.unsplash.com/photo-1506702315536-dd8b83e2dcf9?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1650&q=80)">
+                    <div class="featured-image lazyload"
+                        data-image="https://images.unsplash.com/photo-1506702315536-dd8b83e2dcf9?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1650&q=80">
                     </div>
                     <div class="featured-wrap flex">
                         <div class="featured-content">
@@ -579,7 +579,7 @@
         });
     }
 </script>
-
+<script src="assets/js/lazyload.js"></script>
 
 </body>
 

--- a/how-to-fail-in-iit-entrace-exam.html
+++ b/how-to-fail-in-iit-entrace-exam.html
@@ -20,8 +20,10 @@
     <meta name="HandheldFriendly" content="True">
     <meta name="MobileOptimized" content="320">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap"
-        rel="stylesheet">
+    <link rel="preconect" href="https://fonts.gstatic.com" crossorigin="">
+    <link rel="preconect" href="https://fonts.googleapis.com" crossorigin="">
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap" as="style">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap">
     <link rel="stylesheet" type="text/css" href="assets/css/screen.css">
     <meta name="description" content="Thoughts, stories and ideas" />
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />

--- a/index.html
+++ b/index.html
@@ -123,7 +123,7 @@
             <div id="slider" class="section-scrollable">
 
                 <div class="section-featured asyncImage is-featured-image">
-                    <div class="featured-image" style="background-image: url(https://image.freepik.com/free-vector/help-support-question-mark-scribble-style-background_1017-25237.jpg)">
+                    <div class="featured-image lazyload asyncImage" data-image="https://image.freepik.com/free-vector/help-support-question-mark-scribble-style-background_1017-25237.jpg">
                     </div>
                     <div class="featured-wrap flex">
                         <article class="featured-content">
@@ -146,7 +146,7 @@
                 </div>
 
                 <div class="section-featured asyncImage is-featured-image">
-                    <div class="featured-image" style="background-image: url(https://image.freepik.com/free-vector/left-right-human-brain-cerebral-hemispheres-pictorial-symbolic-colorful-figure-with-flowchart-activity-zones-vector-illustration_98292-3513.jpg)">
+                    <div class="featured-image lazyload asyncImage" data-image="https://image.freepik.com/free-vector/left-right-human-brain-cerebral-hemispheres-pictorial-symbolic-colorful-figure-with-flowchart-activity-zones-vector-illustration_98292-3513.jpg">
                     </div>
                     <div class="featured-wrap flex">
                         <article class="featured-content">
@@ -169,8 +169,8 @@
                 </div>
 
                 <div class="section-featured is-featured-image">
-                    <div class="featured-image asyncImage"
-                        style="background-image: url(https://images.unsplash.com/photo-1522120691812-dcdfb625f397?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=668&q=80)">
+                    <div class="featured-image lazyload asyncImage"
+                        data-image="https://images.unsplash.com/photo-1522120691812-dcdfb625f397?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=668&q=80">
                     </div>
 
                     <div class="featured-wrap flex">
@@ -196,8 +196,8 @@
                 </div>
 
                 <div class="section-featured is-featured-image">
-                    <div class="featured-image asyncImage"
-                        style="background-image: url(https://images.unsplash.com/photo-1579758300918-333e43ba760d?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1567&q=80)">
+                    <div class="featured-image lazyload asyncImage"
+                        data-image="https://images.unsplash.com/photo-1579758300918-333e43ba760d?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1567&q=80">
                     </div>
                     <div class="featured-wrap flex">
                         <article class="featured-content">
@@ -233,7 +233,7 @@
                         <article>
                             <a href="/motitoon/story-of-luck" class="item-link-overlay"
                                 aria-label="Why You Shouldn't Wait For The Finish Line"></a>
-                            <div class="item-image asyncImage" style="background-image: url(https://image.freepik.com/free-vector/help-support-question-mark-scribble-style-background_1017-25237.jpg)">
+                            <div class="item-image lazyload asyncImage" data-image="https://image.freepik.com/free-vector/help-support-question-mark-scribble-style-background_1017-25237.jpg">
                             </div>
                             <h2><a href="/motitoon/story-of-luck" class="white">
                                 THE DILEMMA OF BEING LUCKY!
@@ -251,7 +251,7 @@
                         <article>
                             <a href="/logic-and-mind" class="item-link-overlay"
                                 aria-label="Why You Shouldn't Wait For The Finish Line"></a>
-                            <div class="item-image asyncImage" style="background-image: url(https://image.freepik.com/free-vector/left-right-human-brain-cerebral-hemispheres-pictorial-symbolic-colorful-figure-with-flowchart-activity-zones-vector-illustration_98292-3513.jpg)">
+                            <div class="item-image lazyload asyncImage" data-image="https://image.freepik.com/free-vector/left-right-human-brain-cerebral-hemispheres-pictorial-symbolic-colorful-figure-with-flowchart-activity-zones-vector-illustration_98292-3513.jpg">
                             </div>
                             <h2><a href="/logic-and-mind" class="white">Logic Conflicts with Mind</a>
                             </h2>
@@ -283,8 +283,7 @@
                     <div class="item-wrap flex post tag-lifestyle featured no-image tag-hash-blue">
                         <article>
                             <a href="/mental-health" class="item-link-overlay" aria-label="Mental Health"></a>
-                            <!-- <div class="item-image asyncImage"
-                                style="background-image: url(https://image.freepik.com/free-vector/people-connecting-jigsaw-pieces-head-together_53876-43021.jpg)">
+                            <!-- <div class="item-image lazyload asyncImage" data-image="https://image.freepik.com/free-vector/people-connecting-jigsaw-pieces-head-together_53876-43021.jpg">
                             </div> -->
                             <h2><a href="/mental-health" class="white">Mental Health</a>
                             </h2>
@@ -302,8 +301,7 @@
                         <article>
                             <a href="/the-sparkling-moonlight" class="item-link-overlay"
                                 aria-label="The Sparkling Moonlight"></a>
-                            <div class="item-image asyncImage"
-                                style="background-image: url(https://image.freepik.com/free-vector/realistic-full-moon-sky-background_23-2148419956.jpg)">
+                            <div class="item-image lazyload asyncImage" data-image="https://image.freepik.com/free-vector/realistic-full-moon-sky-background_23-2148419956.jpg">
                             </div>
                             <h2><a href="/the-sparkling-moonlight" class="white">The Sparkling Moonlight</a>
                             </h2>
@@ -320,8 +318,7 @@
                         <article>
                             <a href="/the-tendency-of-hypocritical-admiration" class="item-link-overlay"
                                 aria-label="The Tendency of Hypocritical Admiration"></a>
-                            <div class="item-image asyncImage"
-                                style="background-image: url(https://image.freepik.com/free-vector/two-businessmen-with-masks_1133-276.jpg)">
+                            <div class="item-image lazyload asyncImage" data-image="https://image.freepik.com/free-vector/two-businessmen-with-masks_1133-276.jpg">
                             </div>
                             <h2><a href="/the-tendency-of-hypocritical-admiration" class="white">The Tendency of
                                     Hypocritical Admiration</a>
@@ -338,8 +335,8 @@
                         <article>
                             <a href="/the-dry-petal-in-my-diary" class="item-link-overlay"
                                 aria-label="The Dry Petal In My Diary"></a>
-                            <div class="item-image asyncImage"
-                                style="background-image: url(https://images.unsplash.com/photo-1522836924445-4478bdeb860c?ixlib=rb-1.2.1&auto=format&fit=crop&w=1650&q=80)">
+                            <div class="item-image lazyload asyncImage"
+                                data-image="https://images.unsplash.com/photo-1522836924445-4478bdeb860c?ixlib=rb-1.2.1&auto=format&fit=crop&w=1650&q=80">
                             </div>
                             <h2><a href="/the-dry-petal-in-my-diary" class="white">The Dry Petal In My Diary</a>
                             </h2>
@@ -371,7 +368,7 @@
                         <article>
                             <a href="/memories_of_kota" class="item-link-overlay"
                                 aria-label="Memories of Kota, Where JEE is in The Air…"></a>
-                            <div class="item-image asyncImage" style="background-image: url()">
+                            <div class="item-image lazyload asyncImage" data-image="">
                             </div>
                             <h2><a href="/memories_of_kota" class="white">Memories of Kota, Where JEE is in The Air…</a>
                             </h2>
@@ -400,8 +397,8 @@
                     <div class="item-wrap flex post tag-design featured is-image">
                         <article>
                             <a href="dicision_making" class="item-link-overlay" aria-label=""></a>
-                            <div class="item-image asyncImage"
-                                style="background-image: url(https://images.unsplash.com/photo-1500856056008-859079534e9e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1651&q=80)">
+                            <div class="item-image lazyload asyncImage"
+                                data-image="https://images.unsplash.com/photo-1500856056008-859079534e9e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1651&q=80">
                             </div>
                             <h2><a href="https://storysea.in/dicision_making" class="white">Waiting hurts.
                                     Forgetting hurts. But not knowing which decision to take can sometimes be the most
@@ -610,8 +607,8 @@
                 <path
                     d="M15.4285714,12 L24,20.5714286 L20.5714286,24 L12,15.4285714 L3.42857143,24 L3.55271368e-15,20.5714286 L8.57142857,12 L5.32907052e-15,3.42857143 L3.42857143,3.55271368e-15 L12,8.57142857 L20.5714286,3.55271368e-15 L24,3.42857143 L15.4285714,12 Z" />
             </svg></div>
-        <div class="search-image asyncImage"
-            style="background-image: url(/content/images/2018/12/alisher-sharip-117976-unsplash.jpg)">
+        <div class="search-image lazyload asyncImage"
+            data-image="/content/images/2018/12/alisher-sharip-117976-unsplash.jpg)">
         </div>
         <div class="search-wrap">
             <div class="search-content">
@@ -684,6 +681,7 @@
     <script src="assets/js/index.js?v=62ad10baa0"></script>
     <script src="assets/js/global.js?v=62ad10baa0"></script>
     <script src="assets/js/ityped.js?v=62ad10baa0"></script>
+    <script src="assets/js/lazyload.js"></script>
     <!-- <script>
         
         function getParameterByName(e, n) {

--- a/index.html
+++ b/index.html
@@ -22,8 +22,10 @@
     <meta name="HandheldFriendly" content="True">
     <meta name="MobileOptimized" content="320">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap"
-        rel="stylesheet">
+    <link rel="preconect" href="https://fonts.gstatic.com" crossorigin="">
+    <link rel="preconect" href="https://fonts.googleapis.com" crossorigin="">
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap" as="style">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap">
     <link rel="stylesheet" type="text/css" href="assets/css/screen.css">
     <meta name="description" content="Thoughts, stories and ideas" />
     <link rel="shortcut icon" href="content/images/default.png" type="image/x-icon" />

--- a/logic-and-mind.html
+++ b/logic-and-mind.html
@@ -24,8 +24,10 @@
     <meta name="HandheldFriendly" content="True">
     <meta name="MobileOptimized" content="320">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap"
-        rel="stylesheet">
+    <link rel="preconect" href="https://fonts.gstatic.com" crossorigin="">
+    <link rel="preconect" href="https://fonts.googleapis.com" crossorigin="">
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap" as="style">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap">
     <link rel="stylesheet" type="text/css" href="assets/css/screen.css">
     <meta name="description" content="Thoughts, stories and ideas" />
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />

--- a/memories_of_kota.html
+++ b/memories_of_kota.html
@@ -123,8 +123,8 @@
             </div>
             <article>
                 <div class="section-featured is-featured-image">
-                    <div class="featured-image"
-                        style="background-image: url(https://images.unsplash.com/photo-1545241201-fee9df605ca8?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1650&q=80);">
+                    <div class="featured-image lazyload"
+                        data-image="https://images.unsplash.com/photo-1545241201-fee9df605ca8?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1650&q=80">
                     </div>
                     <div class="featured-wrap flex">
                         <div class="featured-content">
@@ -652,7 +652,7 @@
             });
         }
     </script>
-
+<script src="assets/js/lazyload.js"></script>
 
 </body>
 

--- a/memories_of_kota.html
+++ b/memories_of_kota.html
@@ -24,8 +24,10 @@
     <meta name="HandheldFriendly" content="True">
     <meta name="MobileOptimized" content="320">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap"
-        rel="stylesheet">
+    <link rel="preconect" href="https://fonts.gstatic.com" crossorigin="">
+    <link rel="preconect" href="https://fonts.googleapis.com" crossorigin="">
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap" as="style">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap">
     <link rel="stylesheet" type="text/css" href="assets/css/screen.css">
     <meta name="description" content="Thoughts, stories and ideas" />
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />

--- a/mental-health.html
+++ b/mental-health.html
@@ -120,8 +120,8 @@
             </div>
             <article>
                 <div class="section-featured is-featured-image">
-                    <div class="featured-image"
-                        style="background-image: url(content/images/matal-health.jpg)">
+                    <div class="featured-image lazyload"
+                        data-image="content/images/matal-health.jpg">
                     </div>
                     <div class="featured-wrap flex">
                         <div class="featured-content">
@@ -676,7 +676,7 @@
             });
         }
     </script> -->
-
+    <script src="assets/js/lazyload.js"></script>
     <script>
         var initTyped = document.getElementById("ityped");
         if (initTyped) {

--- a/mental-health.html
+++ b/mental-health.html
@@ -23,8 +23,10 @@
     <meta name="HandheldFriendly" content="True">
     <meta name="MobileOptimized" content="320">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap"
-        rel="stylesheet">
+    <link rel="preconect" href="https://fonts.gstatic.com" crossorigin="">
+    <link rel="preconect" href="https://fonts.googleapis.com" crossorigin="">
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap" as="style">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap">
     <link rel="stylesheet" type="text/css" href="assets/css/screen.css">
     <meta name="description" content="Thoughts, stories and ideas" />
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />

--- a/motitoon/story-of-luck.html
+++ b/motitoon/story-of-luck.html
@@ -25,8 +25,10 @@
     <meta name="HandheldFriendly" content="True">
     <meta name="MobileOptimized" content="320">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap"
-        rel="stylesheet">
+    <link rel="preconect" href="https://fonts.gstatic.com" crossorigin="">
+    <link rel="preconect" href="https://fonts.googleapis.com" crossorigin="">
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap" as="style">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap">
     <link rel="stylesheet" type="text/css" href="../assets/css/screen.css">
     <meta name="description" content="Thoughts, stories and ideas" />
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />

--- a/motitoon/story-of-luck.html
+++ b/motitoon/story-of-luck.html
@@ -110,8 +110,8 @@
             </div>
             <article>
                 <div class="section-featured is-featured-image">
-                    <div class="featured-image"
-                        style="background-image: url(https://image.freepik.com/free-vector/help-support-question-mark-scribble-style-background_1017-25237.jpg)">
+                    <div class="featured-image lazyload"
+                        data-image="https://image.freepik.com/free-vector/help-support-question-mark-scribble-style-background_1017-25237.jpg)">
                     </div>
                     <div class="featured-wrap flex">
                         <div class="featured-content">

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,23 @@
+[build.processing]
+  skip_processing = false
+
+#minify and bundle assets to reduce time compiling and execution
+[build.processing.css]
+  bundle = true
+  minify = true
+[build.processing.js]
+  bundle = true
+  minify = true
+[build.processing.html]
+  pretty_urls = true
+[build.processing.images]
+  compress = true
+
+# Cache control for histories images, caches images for 1 year but must verify first with server for any changes.
+[[headers]]
+  for = "/content/*"
+  [headers.values]
+    cache-control = '''
+    max-age=31536000,
+    no-cache,
+    must-revalidate'''

--- a/the-dry-petal-in-my-diary.html
+++ b/the-dry-petal-in-my-diary.html
@@ -119,8 +119,8 @@
             </div>
             <article>
                 <div class="section-featured is-featured-image">
-                    <div class="featured-image"
-                        style="background-image: url(https://images.unsplash.com/photo-1522836924445-4478bdeb860c?ixlib=rb-1.2.1&auto=format&fit=crop&w=1650&q=80)">
+                    <div class="featured-image lazyload"
+                        data-image="https://images.unsplash.com/photo-1522836924445-4478bdeb860c?ixlib=rb-1.2.1&auto=format&fit=crop&w=1650&q=80">
                     </div>
                     <div class="featured-wrap flex">
                         <div class="featured-content">
@@ -616,7 +616,7 @@
             });
         }
     </script>
-
+<script src="assets/js/lazyload.js"></script>
 </body>
 
 </html>

--- a/the-dry-petal-in-my-diary.html
+++ b/the-dry-petal-in-my-diary.html
@@ -24,8 +24,10 @@
     <meta name="HandheldFriendly" content="True">
     <meta name="MobileOptimized" content="320">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap"
-        rel="stylesheet">
+    <link rel="preconect" href="https://fonts.gstatic.com" crossorigin="">
+    <link rel="preconect" href="https://fonts.googleapis.com" crossorigin="">
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap" as="style">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap">
     <link rel="stylesheet" type="text/css" href="assets/css/screen.css">
     <meta name="description" content="Thoughts, stories and ideas" />
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />

--- a/the-sparkling-moonlight.html
+++ b/the-sparkling-moonlight.html
@@ -23,8 +23,10 @@
     <meta name="HandheldFriendly" content="True">
     <meta name="MobileOptimized" content="320">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap"
-        rel="stylesheet">
+    <link rel="preconect" href="https://fonts.gstatic.com" crossorigin="">
+    <link rel="preconect" href="https://fonts.googleapis.com" crossorigin="">
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap" as="style">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap">
     <link rel="stylesheet" type="text/css" href="assets/css/screen.css">
     <meta name="description" content="Thoughts, stories and ideas" />
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />

--- a/the-sparkling-moonlight.html
+++ b/the-sparkling-moonlight.html
@@ -118,8 +118,8 @@
             </div>
             <article>
                 <div class="section-featured is-featured-image">
-                    <div class="featured-image"
-                        style="background-image: url(https://image.freepik.com/free-vector/realistic-full-moon-sky-background_23-2148419956.jpg)">
+                    <div class="featured-image lazyload"
+                        data-image="https://image.freepik.com/free-vector/realistic-full-moon-sky-background_23-2148419956.jpg">
                     </div>
                     <div class="featured-wrap flex">
                         <div class="featured-content">
@@ -618,7 +618,7 @@
             });
         }
     </script>
-
+<script src="assets/js/lazyload.js"></script>
 </body>
 
 </html>

--- a/the-tendency-of-hypocritical-admiration.html
+++ b/the-tendency-of-hypocritical-admiration.html
@@ -24,8 +24,10 @@
     <meta name="HandheldFriendly" content="True">
     <meta name="MobileOptimized" content="320">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap"
-        rel="stylesheet">
+    <link rel="preconect" href="https://fonts.gstatic.com" crossorigin="">
+    <link rel="preconect" href="https://fonts.googleapis.com" crossorigin="">
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap" as="style">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap">
     <link rel="stylesheet" type="text/css" href="assets/css/screen.css">
     <meta name="description" content="Thoughts, stories and ideas" />
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />

--- a/trusting-people-easily.html
+++ b/trusting-people-easily.html
@@ -124,8 +124,8 @@
             </div>
             <article>
                 <div class="section-featured is-featured-image">
-                    <div class="featured-image"
-                        style="background-image: url(https://images.unsplash.com/photo-1579758300918-333e43ba760d?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1567&q=80);">
+                    <div class="featured-image lazyload"
+                        data-image="https://images.unsplash.com/photo-1579758300918-333e43ba760d?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1567&q=80">
                     </div>
                     <div class="featured-wrap flex">
                         <div class="featured-content">
@@ -591,7 +591,7 @@
             });
         }
     </script>
-
+<script src="assets/js/lazyload.js"></script>
 
 </body>
 

--- a/trusting-people-easily.html
+++ b/trusting-people-easily.html
@@ -22,8 +22,10 @@
     <meta name="HandheldFriendly" content="True">
     <meta name="MobileOptimized" content="320">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap"
-        rel="stylesheet">
+    <link rel="preconect" href="https://fonts.gstatic.com" crossorigin="">
+    <link rel="preconect" href="https://fonts.googleapis.com" crossorigin="">
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap" as="style">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap">
     <link rel="stylesheet" type="text/css" href="assets/css/screen.css">
     <meta name="description" content="Thoughts, stories and ideas - Trusting people too easily!" />
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />

--- a/why-you-shouldn't-wait-for-the-finish-line.html
+++ b/why-you-shouldn't-wait-for-the-finish-line.html
@@ -23,8 +23,10 @@
     <meta name="HandheldFriendly" content="True">
     <meta name="MobileOptimized" content="320">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap"
-        rel="stylesheet">
+    <link rel="preconect" href="https://fonts.gstatic.com" crossorigin="">
+    <link rel="preconect" href="https://fonts.googleapis.com" crossorigin="">
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap" as="style">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap">
     <link rel="stylesheet" type="text/css" href="assets/css/screen.css">
     <meta name="description" content="Thoughts, stories and ideas" />
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />

--- a/why-you-shouldn't-wait-for-the-finish-line.html
+++ b/why-you-shouldn't-wait-for-the-finish-line.html
@@ -118,8 +118,8 @@
             </div>
             <article>
                 <div class="section-featured is-featured-image">
-                    <div class="featured-image"
-                        style="background-image: url(content/images/optimistic.jpg)">
+                    <div class="featured-image lazyload"
+                        data-image="content/images/optimistic.jpg">
                     </div>
                     <div class="featured-wrap flex">
                         <div class="featured-content">
@@ -592,7 +592,7 @@
             });
         }
     </script> -->
-
+    <script src="assets/js/lazyload.js"></script>
     <script>
         var initTyped = document.getElementById("ityped");
         if (initTyped) {


### PR DESCRIPTION
I've added the following improvements on page speed according to #8 

- Added lazyloading using intersection observer for all featured images and item-image on histories.
- Added a netlify config file to optimize assets on build with minification and bundling to reduce http requests, as well as caching headers for content images.
- Added preloading for google fonts.

**Recomendations:**
Now you must embed featured images adding a `.lazyload` class and referencing the image path with `data-image` attribute to keep site performance improvements:
```html
<div class="featured-image lazyload" data-image="https://images.unsplash.com/photo-1500856056008-859079534e9e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1651&q=80">
</div>
```

### Results obtained
Before improvements
![Screenshot_2020-10-02 Lighthouse Report Viewer](https://user-images.githubusercontent.com/7684330/94952109-0aad9980-04ab-11eb-8dd2-7a20db6efec6.png)

After improvements
![Screenshot_2020-10-02 Lighthouse Report Viewer(1)](https://user-images.githubusercontent.com/7684330/94952077-f9648d00-04aa-11eb-9059-a19af2cfe3d3.png)
